### PR TITLE
docs: Increase verbosity of shell example

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -26,8 +26,8 @@ To start items one by one, use this:
 
 .. code-block:: shell
 
-    while true; do rtcontrol --from-view stopped is_complete=y -/1 \
-                             --start --flush -qo name || break; sleep 2; done
+    while true; do rtcontrol --from-view stopped is_complete=y --select=1 --start --flush \
+                             --quiet --output-format=name || break; sleep 2; done
 
 When the bad item is started, the crash might be triggered immediately, or with some delay.
 Increase the sleep time if removing the last item shown (and possibly the one following it)


### PR DESCRIPTION
When reading through the shell example for manipulating torrents, it's
assumed that most users will either copy/paste the command or analyze it
to understand the mechanism of operation.

To make it easier to cross reference the command against `rtorrent
--help`, this commit converts the arguments to their longer form which
will allow users to dissect them one by one.

This should have no affect on users simply copying and pasting.