### PR TITLE
Link fixes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -58,14 +58,14 @@ This reduces the potential of merge conflicts and rework,
 and also makes reviews take a manageable amount of time.
 
 
-.. _`Sphinx tool`: http://www.sphinx-doc.org/
+.. _`Sphinx tool`: https://www.sphinx-doc.org/
 .. _`reStructuredText markup`: http://docutils.sourceforge.net/rst.html
 .. _`CC-BY-SA-4.0`: https://creativecommons.org/licenses/by-sa/4.0/
-.. _`Sphinx reStructuredText Primer`: http://www.sphinx-doc.org/en/stable/rest.html
+.. _`Sphinx reStructuredText Primer`: https://www.sphinx-doc.org/en/stable/rest.html
 .. _`built-in editor`: https://help.github.com/articles/editing-files-in-your-repository/
 .. _`project's README`: https://github.com/rtorrent-community/rtorrent-docs#how-to-build-the-handbook-locally
 .. _`GitHub help`: https://help.github.com/articles/proposing-changes-to-your-work-with-pull-requests/
 .. _`open a pull request`: https://github.com/rtorrent-community/rtorrent-docs/pulls
 .. _`issue tracker`: https://github.com/rtorrent-community/rtorrent-docs/issues
 .. _`Mastering Issues`: https://guides.github.com/features/issues/
-.. _`contribution-guide.org`: http://www.contribution-guide.org/
+.. _`contribution-guide.org`: https://www.contribution-guide.org/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -59,7 +59,7 @@ and also makes reviews take a manageable amount of time.
 
 
 .. _`Sphinx tool`: https://www.sphinx-doc.org/
-.. _`reStructuredText markup`: http://docutils.sourceforge.net/rst.html
+.. _`reStructuredText markup`: https://docutils.sourceforge.io/rst.html
 .. _`CC-BY-SA-4.0`: https://creativecommons.org/licenses/by-sa/4.0/
 .. _`Sphinx reStructuredText Primer`: https://www.sphinx-doc.org/en/stable/rest.html
 .. _`built-in editor`: https://help.github.com/articles/editing-files-in-your-repository/

--- a/docs/cmd-ref.rst
+++ b/docs/cmd-ref.rst
@@ -40,7 +40,7 @@ The following are similar, but incomplete resources:
 -  `wikia.com Reference`_
 
 .. _PyroScope's reference: https://github.com/pyroscope/pyroscope/blob/wiki/RtXmlRpcReference.md
-.. _wikia.com Reference: http://scratchpad.wikia.com/wiki/RTorrentCommands
+.. _wikia.com Reference: https://scratchpad.wikia.com/wiki/RTorrentCommands
 
 
 Download Items and Attributes

--- a/docs/cmd-ref.rst
+++ b/docs/cmd-ref.rst
@@ -37,10 +37,10 @@ The :ref:`generated index <genindex>` also lists all the command names.
 The following are similar, but incomplete resources:
 
 -  `PyroScope's reference`_
--  `wikia.com Reference`_
+-  `Fandom.com Reference`_
 
 .. _PyroScope's reference: https://github.com/pyroscope/pyroscope/blob/wiki/RtXmlRpcReference.md
-.. _wikia.com Reference: https://scratchpad.wikia.com/wiki/RTorrentCommands
+.. _Fandom.com Reference: https://scratchpad.fandom.com/wiki/RTorrentCommands
 
 
 Download Items and Attributes

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -32,7 +32,7 @@ and its configuration in particular.
 
 .. _`RPC Migration 0.9`: https://github.com/rakshasa/rtorrent/wiki/RPC-Migration-0.9
 .. _`sed script`: https://github.com/rakshasa/rtorrent/blob/master/doc/scripts/update_commands_0.9.sed
-.. _`ArchLinux wiki page`: https://wiki.archlinux.org/index.php/Rtorrent
+.. _`ArchLinux wiki page`: https://wiki.archlinux.org/title/Rtorrent
 
 
 .. _rtorrent-basics:

--- a/docs/include-cmd-bt.rst
+++ b/docs/include-cmd-bt.rst
@@ -242,7 +242,7 @@ See the Github wiki for an example of `enabling DHT in rTorrent`_.
 
         **TODO** This does not appear to be in use.
 
-.. _`madvise`: http://man7.org/linux/man-pages/man2/madvise.2.html
+.. _`madvise`: https://man7.org/linux/man-pages/man2/madvise.2.html
 .. _`completed torrents not announcing properly`: https://github.com/rakshasa/rtorrent/issues/437
 
 .. _protocol-commands:
@@ -309,7 +309,7 @@ See the Github wiki for an example of `enabling DHT in rTorrent`_.
 
 .. _`peer exchange`: https://en.wikipedia.org/wiki/Peer_exchange
 
-.. _`BitTorrent protocol encryption`: http://en.wikipedia.org/wiki/BitTorrent_protocol_encryption
+.. _`BitTorrent protocol encryption`: https://en.wikipedia.org/wiki/BitTorrent_protocol_encryption
 
 
 .. _throttle-commands:

--- a/docs/include-cmd-items.rst
+++ b/docs/include-cmd-items.rst
@@ -1506,9 +1506,9 @@ They can also be called directly, but you need to pass `‹infohash›:p‹peerh
 
         Returns the rate and total of the bytes you are uploading to the peer.
 
-.. _`BEP 5`: http://www.bittorrent.org/beps/bep_0005.html
-.. _`BEP 10`: http://www.bittorrent.org/beps/bep_0010.html
-.. _`BEP 20`: http://www.bittorrent.org/beps/bep_0020.html
+.. _`BEP 5`: https://www.bittorrent.org/beps/bep_0005.html
+.. _`BEP 10`: https://www.bittorrent.org/beps/bep_0010.html
+.. _`BEP 20`: https://www.bittorrent.org/beps/bep_0020.html
 .. _`percent encoded`: https://tools.ietf.org/html/rfc3986#section-2.1
 
 .. _t-commands:
@@ -1525,10 +1525,10 @@ Index counting starts at ``0``, the array size is :term:`d.tracker_size`.
 .. code-block:: console
 
     $ rtxmlrpc --repr t.multicall DDEE5CB75C12F3165EF79A12A5CD6158BEF029AD '' t.url=
-    [['http://torrent.ubuntu.com:6969/announce'],
-     ['http://ipv6.torrent.ubuntu.com:6969/announce']]
+    [['https://torrent.ubuntu.com:6969/announce'],
+     ['https://ipv6.torrent.ubuntu.com:6969/announce']]
     $ rtxmlrpc --repr t.url DDEE5CB75C12F3165EF79A12A5CD6158BEF029AD:t0
-    'http://torrent.ubuntu.com:6969/announce'
+    'https://torrent.ubuntu.com:6969/announce'
 
 .. glossary::
 
@@ -1764,7 +1764,7 @@ Index counting starts at ``0``, the array size is :term:`d.tracker_size`.
 
         Returns the full URL of the tracker.
 
-.. _`BEP 12`: http://bittorrent.org/beps/bep_0012.html
+.. _`BEP 12`: https://www.bittorrent.org/beps/bep_0012.html
 
 
 .. _load-commands:

--- a/docs/include-cmd-network.rst
+++ b/docs/include-cmd-network.rst
@@ -18,7 +18,7 @@
            network.http.dns_cache_timeout.set = ‹seconds› ≫ 0
            network.http.dns_cache_timeout ≫ ‹seconds›
 
-        Controls the `DNS cache expiry <https://curl.haxx.se/libcurl/c/CURLOPT_DNS_CACHE_TIMEOUT.html>`_
+        Controls the `DNS cache expiry <https://curl.se/libcurl/c/CURLOPT_DNS_CACHE_TIMEOUT.html>`_
         (in seconds) for HTTP requests. The default is 60 seconds.
 
         Set to zero to completely disable caching, or set to -1 to

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,7 @@ of your distribution, or alternatively install from source (see below).
  * *“Arch User Repository”* (AUR) PKGBUILDs maintained by `@xsmile <https://github.com/xsmile>`_ for
    `libtorrent-ps <https://aur.archlinux.org/packages/libtorrent-ps/>`_ and
    `rtorrent-ps <https://aur.archlinux.org/packages/rtorrent-ps/>`_.
-   See also the *Arch Linux* `wiki page <https://wiki.archlinux.org/index.php/RTorrent#Installation>`_.
+   See also the *Arch Linux* `wiki page <https://wiki.archlinux.org/title/RTorrent#Installation>`_.
 
 
 Automated Installation
@@ -46,7 +46,7 @@ If you want to run *ruTorrent*, the default version of *PHP* is very important (
 
         This will install *rTorrent-PS*, *pyrocore*, and related software onto any remote dedicated server or VPS with root access, running *Debian* or a Debian-like OS. It does so via *Ansible*, which is in many ways superior to the usual *“call a bash script to set up things once and never be able to update them again”*, since you can run this setup repeatedly to either fix problems, or to install upgrades and new features added to the project's repository.
 
-    `QuickBox <https://github.com/QuickBox>`_ and `Swizzin <https://github.com/liaralabs/swizzin>`_
+    `QuickBox <https://github.com/QuickBox>`_ and `Swizzin <https://github.com/swizzin/swizzin>`_
 
         *bash + Javascript*
 
@@ -90,7 +90,7 @@ If you want to run *ruTorrent*, the default version of *PHP* is very important (
 
         Seedbox installation script for *Ubuntu* and *Debian* systems.
 
-    `Kerwood <https://github.com/Kerwood/rtorrent.auto.install>`_
+    `Kerwood <https://github.com/Kerwood/Rtorrent-Auto-Install>`_
 
         *bash · Debian Jessie + Wheezy · Raspian*
 
@@ -118,10 +118,6 @@ including the current bleeding edge of development *(git HEAD)*, or any “relea
         Guide to install *rtorrent*, *ruTorrent*, *Sonarr*, and *CouchPotato* on *Ubuntu*,
         proxied by *Apache httpd*.
 
-    `Installation How-To (LinOxide) <https://linoxide.com/ubuntu-how-to/setup-rtorrent-rutorrent/>`_
-
-        How to install / setup *rTorrent* and *ruTorrent* on *CentOS* or *Ubuntu*.
-
     `Using rtorrent on Linux like a pro <https://web.archive.org/web/20170614105017/https://ahotech.com/2010/06/30/tutorial-using-rtorrent-on-linux-like-a-pro>`_
 
         An oldie (originally from 2010), but still good.
@@ -136,6 +132,6 @@ rTorrent Distributions
 
         A *rTorrent* distribution (not a fork of it), in form of a set of patches that improve the user experience and stability of official *rTorrent* releases. The notable additions are the more condensed ncurses UI with colorization and a network bandwidth graph, and a default configuration providing many new features, based in part on an extended command set.
 
-    `rTorrent-PS-CH <https://github.com/chros73/rtorrent-ps_setup/wiki>`_
+    `rTorrent-PS-CH <https://github.com/chros73/rtorrent-ps-ch_setup/wiki>`_
 
         This puts more patches and a different default configuration on top of *rTorrent-PS*. It also tries to work with the current git HEAD of *rTorrent*, which *rTorrent-PS* does not.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -118,16 +118,11 @@ including the current bleeding edge of development *(git HEAD)*, or any “relea
         Guide to install *rtorrent*, *ruTorrent*, *Sonarr*, and *CouchPotato* on *Ubuntu*,
         proxied by *Apache httpd*.
 
-    `Installation Guide (JES.SC) <https://jes.sc/kb/rTorrent+ruTorrent-Seedbox-Guide.php>`_
-
-        A single-page, comprehensive guide to take you step-by-step through installation and configuration
-        of *rTorrent* and *ruTorrent*.
-
-    `Installation How-To (LinOxide) <http://linoxide.com/ubuntu-how-to/setup-rtorrent-rutorrent/>`_
+    `Installation How-To (LinOxide) <https://linoxide.com/ubuntu-how-to/setup-rtorrent-rutorrent/>`_
 
         How to install / setup *rTorrent* and *ruTorrent* on *CentOS* or *Ubuntu*.
 
-    `Using rtorrent on Linux like a pro <http://ahotech.com/2010/06/30/tutorial-using-rtorrent-on-linux-like-a-pro/>`_
+    `Using rtorrent on Linux like a pro <https://web.archive.org/web/20170614105017/https://ahotech.com/2010/06/30/tutorial-using-rtorrent-on-linux-like-a-pro>`_
 
         An oldie (originally from 2010), but still good.
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -45,7 +45,7 @@ Getting Interactive Help via Chat
 
 .. unofficial help & support channel for rTorrent: irc://irc.freenode.net/rtorrent
 .. webchat: https://webchat.freenode.net/?channels=%23%23rtorrent
-.. freenode.net IRC network: http://freenode.net/
+.. freenode.net IRC network: https://freenode.net/
 
 
 Web Resources Related to rTorrent
@@ -57,7 +57,7 @@ Here is a list of web links to related information:
 * `libtorrent GitHub project <https://github.com/rakshasa/libtorrent>`_
 * `rTorrent Community GitHub organization <https://rtorrent-community.github.io/>`_
 * `Arch Wiki rTorrent page <https://wiki.archlinux.org/index.php/RTorrent>`_
-* `rTorrent Quick Reference Card <http://ciux.org/rtorrent_ref.pdf>`_ (PDF)
+* `rTorrent Quick Reference Card <https://ciux.org/rtorrent_ref.pdf>`_ (PDF)
 
 .. * ` <>`_
 .. END overview

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -56,7 +56,7 @@ Here is a list of web links to related information:
 * `rtorrent GitHub project <https://github.com/rakshasa/rtorrent/>`_
 * `libtorrent GitHub project <https://github.com/rakshasa/libtorrent>`_
 * `rTorrent Community GitHub organization <https://rtorrent-community.github.io/>`_
-* `Arch Wiki rTorrent page <https://wiki.archlinux.org/index.php/RTorrent>`_
+* `Arch Wiki rTorrent page <https://wiki.archlinux.org/title/RTorrent>`_
 * `rTorrent Quick Reference Card <https://ciux.org/rtorrent_ref.pdf>`_ (PDF)
 
 .. * ` <>`_

--- a/docs/use-cases.rst
+++ b/docs/use-cases.rst
@@ -148,7 +148,7 @@ Install the full script by calling these commands:
     wget $gh_raw/master/docs/examples/rename2tied.sh -O $_/rename2tied.sh
     chmod a+rx $_
 
-Note that you also **must** have `pyrocore <http://pyrocore.readthedocs.io/>`_ installed,
+Note that you also **must** have `pyrocore <https://pyrocore.readthedocs.io/>`_ installed,
 so that the ``rtcontrol`` and ``rtxmlrpc`` commands are available.
 
 This is the configuration snippet that binds calling the script to the ``R`` key.
@@ -318,6 +318,6 @@ Run such a script very regularly (via ``cron``),
 to enforce the bandwidth rules continuously.
 
 
-.. _`throttling when other computers are visible on the network`: http://pyrocore.readthedocs.io/en/latest/advanced.html#global-throttling-when-other-computers-are-up
+.. _`throttling when other computers are visible on the network`: https://pyrocore.readthedocs.io/en/latest/advanced.html#global-throttling-when-other-computers-are-up
 
 .. END cookbook


### PR DESCRIPTION
`docs/Makefile linkcheck` now only shows false positives for Github anchors, and 302 redirects.